### PR TITLE
Tool 1 (Analysis that is not in starter list): Integrated Complexity-Report into our CI/CD pipeline

### DIFF
--- a/.complexrc
+++ b/.complexrc
@@ -1,0 +1,8 @@
+{
+  "output": "complexity_report.md",
+  "format": "markdown",
+  "allfiles": false,
+  "ignoreerrors": true,
+  "filepattern": "\\.js$",
+  "dirpattern": "(src)"
+}

--- a/complexity_report.md
+++ b/complexity_report.md
@@ -1,0 +1,29 @@
+Mean per-function logical LOC: 18
+Mean per-function parameter count: 3
+Mean per-function cyclomatic complexity: 1
+Mean per-function Halstead effort: 10734.042662663262
+Mean per-module maintainability index: 92.43435721883823
+First-order density: 0%
+Change cost: 100%
+Core size: 0%
+
+src/routes/api.js
+
+  Physical LOC: 45
+  Logical LOC: 23
+  Mean parameter count: 3
+  Cyclomatic complexity: 1
+  Cyclomatic complexity density: 4.3478260869565215%
+  Maintainability index: 92.43435721883823
+  Dependency count: 4
+
+  Function: module.exports
+    Line No.: 8
+    Physical LOC: 38
+    Logical LOC: 18
+    Parameter count: 3
+    Cyclomatic complexity: 1
+    Cyclomatic complexity density: 5.555555555555555%
+    Halstead difficulty: 6.411290322580645
+    Halstead volume: 1674.2406165663451
+    Halstead effort: 10734.042662663262


### PR DESCRIPTION
Integrated Complexity-Report Static Analysis Tool

Evidence it was installed (screenshot below): 
<img width="786" alt="Screenshot 2024-10-24 at 12 29 14 PM" src="https://github.com/user-attachments/assets/b4c74d4e-bf08-4c02-9841-51e2be91567f">


The above screenshot shows that it has been added to our package.json file as well.

Evidence the tool was run on the repository: https://github.com/CMU-313/nodebb-f24-team-five-guys/pull/44/files

